### PR TITLE
Agent: Fix color system drift in the docs.koi.eco shell components ...

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,18 @@
 import { type Metadata } from 'next'
 import glob from 'fast-glob'
 import Script from 'next/script'
+import { Open_Sans } from 'next/font/google'
 
 import { Providers } from '@/app/providers'
 import { Layout } from '@/components/Layout'
 import { type Section } from '@/components/SectionProvider'
 
 import '@/styles/tailwind.css'
+
+const openSans = Open_Sans({
+  subsets: ['latin'],
+  variable: '--font-open-sans',
+})
 
 export const metadata: Metadata = {
   title: {
@@ -36,7 +42,7 @@ export default async function RootLayout({
         crossOrigin="anonymous"
         strategy="lazyOnload"
       />
-      <html lang="en" className="h-full" suppressHydrationWarning>
+      <html lang="en" className={`h-full ${openSans.variable}`} suppressHydrationWarning>
         <body className="flex min-h-full bg-koiGray-800 antialiased">
           <Providers>
             <div className="w-full">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -31,7 +31,7 @@ function PageLink({
         href={page.href}
         tabIndex={-1}
         aria-hidden="true"
-        className="text-base font-semibold text-zinc-900 transition hover:text-zinc-600 dark:text-white dark:hover:text-zinc-300"
+        className="text-base font-semibold text-koiGray-700 transition hover:text-koiGray-300 dark:text-koiGray-100 dark:hover:text-koiGray-200"
       >
         {page.title}
       </Link>
@@ -89,7 +89,7 @@ function SocialLink({
     >
       <span className="sr-only">{children}</span>
       <i
-        className={`h-5 w-5 fill-zinc-700 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-500 ${icon}`}
+        className={`h-5 w-5 fill-koiGray-300 transition group-hover:fill-koiGray-700 dark:group-hover:fill-koiGray-200 ${icon}`}
       />
     </Link>
   )
@@ -97,8 +97,8 @@ function SocialLink({
 
 function SmallPrint() {
   return (
-    <div className="flex flex-col items-center justify-between gap-5 border-t border-zinc-900/5 pt-8 sm:flex-row dark:border-white/5">
-      <p className="text-xs text-zinc-600 dark:text-zinc-400">
+    <div className="flex flex-col items-center justify-between gap-5 border-t border-koiGray-900/5 pt-8 sm:flex-row dark:border-white/5">
+      <p className="text-xs text-koiGray-300 dark:text-koiGray-200">
         &copy; Copyright {new Date().getFullYear()}. All rights reserved.
       </p>
       <div className="flex gap-4">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,7 +27,7 @@ function TopLevelNavItem({
       <Link
         href={href}
         target={target}
-        className="text-sm leading-5 text-zinc-600 transition hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+        className="text-sm leading-5 text-koiGray-300 transition hover:text-koiGray-700 dark:text-koiGray-200 dark:hover:text-koiGray-100"
       >
         {children}
       </Link>
@@ -56,8 +56,8 @@ export const Header = forwardRef<
         !isInsideNavigationMobile &&
           'backdrop-blur-sm lg:left-72 dark:backdrop-blur',
         isInsideNavigationMobile
-          ? 'bg-white dark:bg-zinc-900'
-          : 'bg-white/[var(--bg-opacity-light)] dark:bg-zinc-900/[var(--bg-opacity-dark)]'
+          ? 'bg-white dark:bg-koiGray-800'
+          : 'bg-white/[var(--bg-opacity-light)] dark:bg-koiGray-800/[var(--bg-opacity-dark)]'
       )}
       style={
         {
@@ -70,7 +70,7 @@ export const Header = forwardRef<
         className={clsx(
           'absolute inset-x-0 top-full h-px transition',
           (isInsideNavigationMobile || !mobileNavIsOpen) &&
-            'bg-zinc-900/7.5 dark:bg-white/7.5'
+            'bg-koiGray-900/7.5 dark:bg-white/7.5'
         )}
       />
       <Search />
@@ -101,7 +101,7 @@ export const Header = forwardRef<
             </TopLevelNavItem>
           </ul>
         </nav>
-        <div className="hidden md:block md:h-5 md:w-px md:bg-zinc-900/10 md:dark:bg-white/15" />
+        <div className="hidden md:block md:h-5 md:w-px md:bg-koiGray-900/10 md:dark:bg-white/15" />
         <div className="flex gap-4">
           <MobileSearch />
         </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -21,7 +21,7 @@ function MobileTopLevelNavItem({
     <li className="md:hidden">
       <Link
         href={href}
-        className="block py-1 text-sm text-zinc-600 transition hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white"
+        className="block py-1 text-sm text-koiGray-300 transition hover:text-koiGray-700 dark:text-koiGray-200 dark:hover:text-koiGray-100"
       >
         {children}
       </Link>
@@ -55,8 +55,8 @@ export function NavLink({
         'flex justify-start gap-2 py-1 pr-3 text-sm transition',
         isAnchorLink ? 'pl-7' : 'pl-4',
         active
-          ? 'rounded-r-md border-l-2 border-cyan-500 bg-white/5 text-zinc-900 dark:text-white'
-          : 'text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-white'
+          ? 'rounded-r-md border-l-2 border-koiBlue-400 bg-white/5 text-koiGray-700 dark:text-koiGray-100'
+          : 'text-koiGray-300 hover:text-koiGray-700 dark:text-koiGray-200 dark:hover:text-koiGray-100'
       )}
     >
       {icon && (
@@ -94,14 +94,14 @@ function NavigationGroup({
     <li className={clsx('relative mt-6', className)}>
       <motion.h2
         layout="position"
-        className="text-xs font-semibold text-zinc-900 dark:text-white"
+        className="text-xs font-semibold text-koiGray-700 dark:text-koiGray-100"
       >
         {group.title}
       </motion.h2>
       <div className="relative mt-3 pl-2">
         <motion.div
           layout
-          className="absolute inset-y-0 left-2 w-px bg-zinc-900/10 dark:bg-white/5"
+          className="absolute inset-y-0 left-2 w-px bg-koiGray-900/10 dark:bg-white/5"
         />
         <ul role="list" className="border-l border-transparent">
           {group.links.map((link, idx) => (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -31,6 +31,9 @@ export default {
     typography: typographyStyles,
     extend: {
       colors: { ...koiColors },
+      fontFamily: {
+        sans: ['var(--font-open-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
       boxShadow: {
         glow: '0 0 4px rgb(0 0 0 / 0.1)',
       },


### PR DESCRIPTION
        ## Agent Job: `docs-koi-eco-20260313-232434-kbdr`

        **Repo:** docs-koi-eco
        **Prompt:** Fix color system drift in the docs.koi.eco shell components (Header, Navigation, Footer) and align the font with the koi.eco landing page.

## Context

The site has a Koi design system in src/lib/koiColors.js with koiGray, koiBlue, etc. The body bg is bg-koiGray-800 (correct). But Header, Navigation, and Footer drift to generic Tailwind zinc-* colors. Fix each file below. Site defaults to dark mode. No new npm dependencies.

After making all changes, run npm run build from the repo root. Fix any type errors before finishing.

## File 1: src/components/Header.tsx

Read this file first. Then make these changes:

1. In TopLevelNavItem link className: replace
   text-zinc-600 -> text-koiGray-300
   hover:text-zinc-900 -> hover:text-koiGray-700
   dark:text-zinc-400 -> dark:text-koiGray-200
   dark:hover:text-white -> dark:hover:text-koiGray-100

2. In the motion.div className where mobile nav background is set:
   dark:bg-zinc-900 -> dark:bg-koiGray-800
   (appears twice: once in isInsideNavigationMobile branch, once in the ternary)

3. In the bottom border div (conditional bg class):
   bg-zinc-900/7.5 -> bg-koiGray-900/7.5

4. In the vertical divider between nav and sign-in button:
   md:bg-zinc-900/10 -> md:bg-koiGray-900/10

## File 2: src/components/Navigation.tsx

Read this file first. Then make these changes:

1. In MobileTopLevelNavItem link className: replace
   text-zinc-600 -> text-koiGray-300
   hover:text-zinc-900 -> hover:text-koiGray-700
   dark:text-zinc-400 -> dark:text-koiGray-200
   dark:hover:text-white -> dark:hover:text-koiGray-100

2. In NavLink active state className: replace
   border-cyan-500 -> border-koiBlue-400
   text-zinc-900 -> text-koiGray-700
   dark:text-white -> dark:text-koiGray-100

3. In NavLink inactive state className: replace
   text-zinc-600 -> text-koiGray-300
   hover:text-zinc-900 -> hover:text-koiGray-700
   dark:text-zinc-400 -> dark:text-koiGray-200
   dark:hover:text-white -> dark:hover:text-koiGray-100

4. In NavigationGroup motion.h2 className: replace
   text-zinc-900 -> text-koiGray-700
   dark:text-white -> dark:text-koiGray-100

5. In NavigationGroup vertical bar motion.div className: replace
   bg-zinc-900/10 -> bg-koiGray-900/10

## File 3: src/components/Footer.tsx

Read this file first. Then make these changes:

1. In PageLink's Link component className: replace
   text-zinc-900 -> text-koiGray-700
   hover:text-zinc-600 -> hover:text-koiGray-300
   dark:text-white -> dark:text-koiGray-100
   dark:hover:text-zinc-300 -> dark:hover:text-koiGray-200

2. In SocialLink icon className: replace
   fill-zinc-700 -> fill-koiGray-300
   group-hover:fill-zinc-900 -> group-hover:fill-koiGray-700
   dark:group-hover:fill-zinc-500 -> dark:group-hover:fill-koiGray-200

3. In SmallPrint border div className: replace
   border-zinc-900/5 -> border-koiGray-900/5

4. In SmallPrint copyright text className: replace
   text-zinc-600 -> text-koiGray-300
   dark:text-zinc-400 -> dark:text-koiGray-200

## File 4: Font -- src/app/layout.tsx + tailwind.config.ts

The koi.eco landing page uses Open Sans as its font. The docs site has no explicit font (uses Tailwind default sans). Add Open Sans via next/font/google (built into Next.js 14, no new npm package needed).

1. In src/app/layout.tsx, add after the existing imports:

import { Open_Sans } from 'next/font/google'

const openSans = Open_Sans({
  subsets: ['latin'],
  variable: '--font-open-sans',
})

2. Apply the variable class to the html element:
   BEFORE: <html lang="en" className="h-full" suppressHydrationWarning>
   AFTER:  <html lang="en" className={`h-full ${openSans.variable}`} suppressHydrationWarning>

3. In tailwind.config.ts, inside theme.extend, add:
   fontFamily: {
     sans: ['var(--font-open-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
   },

## Verification

Run npm run build. Fix any TypeScript or build errors. The build must pass before finishing.

## Acceptance criteria
- All zinc-* classes replaced with koiGray-* equivalents in Header, Navigation, Footer
- border-cyan-500 -> border-koiBlue-400 for active nav indicator
- Open Sans loaded and applied site-wide via CSS variable
- npm run build passes with no errors

        ---
        Automated PR from background agent dispatch on pve-worker-01.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual/styling change: updates Tailwind class names and global font loading without touching application logic or data flows.
> 
> **Overview**
> Aligns the docs shell UI with the Koi design system by replacing remaining `zinc-*` (and `cyan`) Tailwind colors in `Header`, `Navigation`, and `Footer` with `koiGray-*` and `koiBlue-*` equivalents for text, borders, hover states, and active nav styling.
> 
> Applies Open Sans site-wide by loading it via `next/font/google` in `src/app/layout.tsx`, attaching its CSS variable to the `<html>` element, and configuring Tailwind’s `fontFamily.sans` to use `--font-open-sans`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1deec8c1b5d77a394438937d90cd7d7dbc250da. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->