### PR TITLE
fix: typo in methodology alignment

### DIFF
--- a/src/app/docs/data-and-methodology/methodology-alignment/page.mdx
+++ b/src/app/docs/data-and-methodology/methodology-alignment/page.mdx
@@ -169,7 +169,7 @@ practices around boundary setting, baseline selection, and transparency in assum
 We see WBCSD's work as particularly relevant for enterprises seeking to quantify product-level
 climate contributions in credible, investment-grade ways. WBCSD's standardized avoided emissions reporting template (linked in their Implementation Hub) can be readily populated with data and results from a Koi model.
 
-Koi users seeking to follow WBCSD's framework set the solution scale to represent deployed climate solution units and their expected lifetime. The eligbility and classification criteria from WBCSD must also be considered during reporting; Koi is currently agnostic to these considerations and allows for modeling of any intervention.
+Koi users seeking to follow WBCSD's framework set the solution scale to represent deployed climate solution units and their expected lifetime. The eligibility and classification criteria from WBCSD must also be considered during reporting; Koi is currently agnostic to these considerations and allows for modeling of any intervention.
 
 <strong>Target group:</strong> Large corporates
 


### PR DESCRIPTION
## Summary
- Fixes `eligbility` -> `eligibility` typo in methodology-alignment page (WBCSD section)

Spotted while reviewing PR #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that fixes a spelling error with no impact on runtime behavior.
> 
> **Overview**
> Fixes a typo in the WBCSD section of `src/app/docs/data-and-methodology/methodology-alignment/page.mdx`, correcting `eligbility` to `eligibility`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 643f4442f45afd67403f9bdc1af407561fe9420c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->